### PR TITLE
#119: added example using the new caret_position variable

### DIFF
--- a/Example shell commands/Example shell commands.md
+++ b/Example shell commands/Example shell commands.md
@@ -5,5 +5,6 @@
 - [[Launch external applications]]
 - [[Obsidian URI]]
 - [[Open a website]]
+- [[Open the current file in vscode and jump to the current position]]
 
 These are just examples, and this plugin **does not** define them for you automatically. They are listed only to give you ideas of what kind of commands you could configure yourself.

--- a/Example shell commands/Open the current file in vscode and jump to the current position.md
+++ b/Example shell commands/Open the current file in vscode and jump to the current position.md
@@ -1,4 +1,4 @@
 # Example
 
 ## Windows/Mac/Linux
- - If you have the [Visual Studio Code] editor installed on your system (and the shell command available), you can easily jump between obsidian and VSCode using the following SC command: `code --goto {{file_position:absolute}}:{{caret_position}}`
+ - If you have the [Visual Studio Code](https://code.visualstudio.com/) editor installed on your system (and the shell command available), you can easily jump between Obsidian and VSCode using the following SC command: `code --goto {{file_path:absolute}}:{{caret_position}}`

--- a/Example shell commands/Open the current file in vscode and jump to the current position.md
+++ b/Example shell commands/Open the current file in vscode and jump to the current position.md
@@ -1,0 +1,4 @@
+# Example
+
+## Windows/Mac/Linux
+ - If you have the [Visual Studio Code] editor installed on your system (and the shell command available), you can easily jump between obsidian and VSCode using the following SC command: `code --goto {{file_position:absolute}}:{{caret_position}}`


### PR DESCRIPTION
# Description 
Added an example to the docs using the new `caret_position` variable. This is associated with [issue #119](https://github.com/Taitava/obsidian-shellcommands/issues/119) in the obisidian-shellcommands repo

Change Type: enhancement
