### PR TITLE
Add example for Event: File created.md

### DIFF
--- a/Events/File created.md
+++ b/Events/File created.md
@@ -28,7 +28,10 @@ In addition to [[Variables - general principles#^normal-variables|normal variabl
 **Note:** Accessing these variables outside an event that supports them will trigger an error message and prevent executing the shell command.
 
 ## Examples
-- [[]] #TODO: Add an example.
+- Change incoming .txt files to .md files automatically:
+> {{event_file_name}}
+> cd {{event_folder_path:absolute}}; for f in *.txt; do mv -- "$f" "${f%.txt}.md"; done
+  
 
 ## Based on
 The Obsidian event that powers this feature is [`create` on `vault` events](https://github.com/obsidianmd/obsidian-api/blob/763a243b4ec295c9c460560e9b227c8f18d8199b/obsidian.d.ts#L3256).


### PR DESCRIPTION
Thought this might come in handy as an example for the Event: File created.

I'm not sure I need both events here though.
```
{{event_file_name}}

cd {{event_folder_path:absolute}}; for f in *.txt; do mv -- "$f" "${f%.txt}.md"; done
```